### PR TITLE
fix: replace return type torch.Any with torch.Tensor

### DIFF
--- a/autoware_rosbag2_anonymizer/model/open_clip.py
+++ b/autoware_rosbag2_anonymizer/model/open_clip.py
@@ -14,7 +14,7 @@ class OpenClipModel:
         )
         self.tokenizer = open_clip.get_tokenizer("ViT-B-32")
 
-    def __call__(self, image: Image.Image, promt: list[str]) -> torch.Any:
+    def __call__(self, image: Image.Image, promt: list[str]) -> torch.Tensor:
         image = self.preprocess(image).unsqueeze(0).to(self.device)
         text = self.tokenizer(promt).to(self.device)
 


### PR DESCRIPTION
Replace the return type `torch.Any` (which does not exist) with `torch.Tensor` to fix runtime errors.